### PR TITLE
Fixed bug that cause error when reading os cache size when the folder doesn't exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,13 +189,18 @@ function ClearCache() {
 }
 
 function GetOSCacheSize() {
-  var totalBytes = 0;
-  let filenames = fs.readdirSync(`${__dirname}/OSCache/`);
+  try {
+    var totalBytes = 0;
+    let filenames = fs.readdirSync(`${__dirname}/OSCache/`);
   
-  filenames.forEach((file) => {
-      fs.stat(`${__dirname}/OSCache/` + file, function(err, stats) {
-        totalBytes = totalBytes + stats.size;
-        osCacheSize = convertBytes(totalBytes);
+    filenames.forEach((file) => {
+        fs.stat(`${__dirname}/OSCache/` + file, function(err, stats) {
+          totalBytes = totalBytes + stats.size;
+          osCacheSize = convertBytes(totalBytes);
+        });
       });
-  });
+    }
+  catch {
+    console.warn("WARN: Failed to read OS Cache file size. The file has probably not been created.");
+  }
 }


### PR DESCRIPTION
I fixed a bug that caused the program to though an error when reading the size of the OSCache folder. The error was caused by the folder not existing when the function was called.